### PR TITLE
Bastion host needs to be in EC2 security group

### DIFF
--- a/doc_source/blockchain-templates-create-stack.md
+++ b/doc_source/blockchain-templates-create-stack.md
@@ -22,7 +22,7 @@ When you launch the AWS CloudFormation stack using the template, it creates nest
    + For **EC2 Security Group**, select the security group you created earlier in [Create Security Groups](blockchain-template-getting-started-prerequisites.md#blockchain-templates-create-security-group)\.
    + For **IAM Role for ECS**, enter the ARN of the ECS role that you created earlier in [Create an IAM Role for Amazon ECS and an EC2 Instance Profile](blockchain-template-getting-started-prerequisites.md#blockchain-templates-iam-roles)\.
    + For **EC2 Instance Profile ARN**, enter the ARN of the instance profile that you created earlier in [Create an IAM Role for Amazon ECS and an EC2 Instance Profile](blockchain-template-getting-started-prerequisites.md#blockchain-templates-iam-roles)\.
-   + For **Application Load Balancer Security Group**, select the security group for the Application Load Balancer that you created earlier in [Create Security Groups](blockchain-template-getting-started-prerequisites.md#blockchain-templates-create-security-group)\.
+   + For **Application Load Balancer Security Group**, select the security group for the Application Load Balancer and the EC2 security group that you created earlier in [Create Security Groups](blockchain-template-getting-started-prerequisites.md#blockchain-templates-create-security-group)\.
    + Under **ECS cluster configuration**, leave the defaults, which creates an ECS cluster of three EC2 instances\.\.
    + For **EthStats**, leave the default setting, which is *true*\.
    + For **EthStats Connection Secret**, type an arbitrary value that is at least six characters\.


### PR DESCRIPTION
Unless I am missing a step in the documentation (totally possible, but I did go through it three times), the Bastion host needs to also be in the EC2 security group. If it is not, then the Explorer will not work, and will give the error 'allow Access to Geth and Refresh the Page'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
