### PR TITLE
Update latest Ethereum release

### DIFF
--- a/doc_source/blockchain-templates-ethereum.md
+++ b/doc_source/blockchain-templates-ethereum.md
@@ -1,6 +1,6 @@
 # Using the AWS Blockchain Template for Ethereum<a name="blockchain-templates-ethereum"></a>
 
-Ethereum is a blockchain framework that runs smart contracts using Solidity, an Ethereum\-specific language\. Homestead is the most recent release of Ethereum\. For more information, see the [Ethereum Homestead Documentation](http://www.ethdocs.org/en/latest/) and the [Solidity](https://solidity.readthedocs.io/en/v0.4.21/#) documentation\.
+Ethereum is a blockchain framework that runs smart contracts using Solidity, an Ethereum\-specific language\. Constantinople is the most recent release of Ethereum\. For more information, see the [Ethereum Homestead Documentation](http://www.ethdocs.org/en/latest/) and the [Solidity](https://solidity.readthedocs.io/en/v0.4.21/#) documentation\.
 
 ## Links to Launch<a name="blockchain-ethereum-launch"></a>
 


### PR DESCRIPTION
Homestead was released on 2016-03-14. The latest release of Ethereum is Metropolis (vConstantinople), which was released on 2019-02-28.

*Issue #, if available:* N/A

*Description of changes:* This change updates the `Using the AWS Blockchain Template for Ethereum` document to note the correct latest version of Ethereum.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.